### PR TITLE
Fix for `cordova not initialized when app launched in background`

### DIFF
--- a/src/ios/CDVBackgroundFetch.m
+++ b/src/ios/CDVBackgroundFetch.m
@@ -73,9 +73,9 @@
 -(void) onFetch:(NSNotification *) notification
 {
     NSLog(@"- CDVBackgroundFetch onFetch");
-    if (!self.fetchCallbackId) {
-        return;
-    }
+    //if (!self.fetchCallbackId) {
+    //    return;
+    //}
     _notification = notification;
     _completionHandler = [notification.object copy];
     


### PR DESCRIPTION
Fixes issue described [here](https://github.com/christocracy/cordova-plugin-background-fetch/issues/4) and [here](https://github.com/christocracy/cordova-plugin-background-fetch/issues/10) where app would receive the following error:

```
CDVBackgroundFetch onFetch
Warning: Application delegate received call to -application:performFetchWithCompletionHandler: but the completion handler was never called.
```

when launched from a background fetch.